### PR TITLE
Support vendor handlers, processors and formatters.

### DIFF
--- a/Lib/Log/Engine/MonologLogger.php
+++ b/Lib/Log/Engine/MonologLogger.php
@@ -77,6 +77,12 @@ class MonologLogger implements CakeLogInterface {
 		$class = $name;
 		if (strpos($class, $type) === false) {
 			$class = "\Monolog\\$type\\$name$type";
+		} else if (isset($params['search'])) {
+			if (strpos($params['search'], '.php') === false) {
+				$params['search'] .= DS . $class . '.php';
+			}
+			include $params['search'];
+			unset($params['search']);
 		}
 
 		if ('Handler' === $type) {

--- a/Lib/Log/Handler/CakeEmailHandler.php
+++ b/Lib/Log/Handler/CakeEmailHandler.php
@@ -1,0 +1,51 @@
+<?php
+use Monolog\Logger;
+use Monolog\Handler\MailHandler;
+
+/**
+ * CakeEmailHandler uses CakeEmail to send the emails.
+ *
+ * Use it like so:
+ *
+ * CakeLog::config('web', array(
+ *    'engine' => 'Monolog.MonologLogger',
+ *    'channel' => 'web',
+ *    'handlers' => array(
+ *        'CakeEmailHandler' => array(
+ *            "webmaster@domain.com",
+ *            "ALERT: IMMEDIATE ACTION REQUIRED.",
+ *            'default',
+ *            'search' => CakePlugin::path('Monolog') . DS . 'Lib' . DS . 'Log' . DS . 'Handler'
+ *        )
+ *    )
+ *));
+ *
+*/
+class CakeEmailHandler extends \Monolog\Handler\MailHandler {
+
+    protected $_to;
+    protected $_subject;
+    protected $_config;
+
+    /**
+     * @param string|array $to      The receiver of the mail
+     * @param string       $subject The subject of the mail
+     * @param string       $from    The CakeEmail configuration to use
+     * @param integer      $level   The minimum logging level at which this handler will be triggered
+     * @param boolean      $bubble  Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct($to, $subject, $config = 'default', $level = Logger::ERROR, $bubble = true) {
+        parent::__construct($level, $bubble);
+        $this->_to = $to;
+        $this->_subject = $subject;
+        $this->_config = $config;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send($content, array $records) {
+        \CakeEmail::deliver($this->_to, $this->_subject, $content, $this->_config);
+    }
+
+}


### PR DESCRIPTION
The need came out of having to implement `CakeEmailHandler` into the plugin itself since the [pull request](https://github.com/Seldaek/monolog/pull/162) was [declined](https://github.com/Seldaek/monolog/pull/162#issuecomment-13488664) and rightfully so, since now it supports all other monolog external libraries.
