### PR TITLE
Additional try to locate monolog package

### DIFF
--- a/Lib/Log/Engine/MonologLogger.php
+++ b/Lib/Log/Engine/MonologLogger.php
@@ -18,9 +18,12 @@ class MonologLogger extends BaseLog {
 		if (!isset($search) || empty($search) || !is_dir($search)) {
 			$search = dirname(dirname(dirname(CakePlugin::path('Monolog')))) . DS . 'vendor' . DS;
 			if (!is_dir($search . 'monolog')) {
-				$search = $search = dirname(dirname(dirname(dirname(__FILE__)))) . DS . 'vendor' . DS;
+				$search = dirname(dirname(dirname(dirname(__FILE__)))) . DS . 'vendor' . DS;
 				if (!is_dir($search . 'monolog')) {
-					throw new Exception("Missing the monolog/monolog composer package.");
+					$search = APP . 'Vendor' . DS;
+					if (!is_dir($search . 'monolog')) {
+						throw new Exception("Missing the monolog/monolog composer package.");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Having configured the composer.json of my app with

```
  "config": {"vendor-dir": "Vendor"}
```

which I assume is a fairly common option, the monolog package is located in app/Vendor. And the plugin cannot find it.

Of course with the 'search' param in CakeLog::config this can be solved, but maybe is better to take care of this directly in the plugin.
