### PR TITLE
Fixed possible 'Undefined offset' warning.

### DIFF
--- a/Lib/Log/Engine/MonologLogger.php
+++ b/Lib/Log/Engine/MonologLogger.php
@@ -100,6 +100,8 @@ class MonologLogger extends BaseLog {
 			$method = 'setFormatter';
 		}
 
+		$params = array_values($params);
+
 		switch(count($params)) {
 			case 1:
 				$_class = new $class($params[0]);


### PR DESCRIPTION
unset() does not renumber the array keys. An 'Undefined offset' warning may be issued when mixing named and unnamed parameters with CakeEmail handler.

Test case:

CakeLog::config('default', array(
    'engine' => 'Monolog.MonologLogger',
    'search' => APP.'Vendor/',
    'channel' => 'app',
    'handlers' => array(
        // ...
        'CakeEmail' => array(
            'me@somewhere.com',
            'Email Subject',
            'default',
            400 /\* minimum level >= Logger::ERROR */,
            'formatters' => array(
                'Line' => array("...%message%")
            ),
            'processors' => array(
                'Introspection',
            ),
            'search' => CakePlugin::path('Monolog').DS.'Lib'.DS.'Log'.DS.'Handler',
        ),
    )
));

Warning message:

Notice (8): Undefined offset: 4 [APP/Plugin/Monolog/Lib/Log/Engine/MonologLogger.php, line 127]
