### PR TITLE
Use reflection to pass arguments instead of broken switch.

### DIFF
--- a/Lib/Log/Engine/MonologLog.php
+++ b/Lib/Log/Engine/MonologLog.php
@@ -109,8 +109,8 @@ class MonologLog extends BaseLog {
 
 		$params = array_values($params);
 
-		$class_reflector = new ReflectionClass($class);
-		$_class = $class_reflector->newInstanceArgs($params);
+		$classReflector = new ReflectionClass($class);
+		$_class = $classReflector->newInstanceArgs($params);
 		$object->$method($_class);
 
 		foreach ($extras as $k) {

--- a/Lib/Log/Engine/MonologLog.php
+++ b/Lib/Log/Engine/MonologLog.php
@@ -109,36 +109,9 @@ class MonologLog extends BaseLog {
 
 		$params = array_values($params);
 
-		switch(count($params)) {
-			case 1:
-				$_class = new $class($params[0]);
-				$object->$method($_class);
-			break;
-
-			case 2:
-				$_class = new $class($params[0], $params[1]);
-				$object->$method($_class);
-			break;
-
-			case 3:
-				$_class = new $class($params[0], $params[1], $params[2]);
-				$object->$method($_class);
-			break;
-
-			case 4:
-				$_class = new $class($params[0], $params[1], $params[2], $params[3]);
-				$object->$method($_class);
-			break;
-
-			case 5:
-				$_class = new $class($params[0], $params[1], $params[2], $params[3], $params[4]);
-				$object->$method($_class);
-			break;
-
-			default:
-				$_class = new $class();
-				$object->$method($_class);
-		}
+		$class_reflector = new ReflectionClass($class);
+		$_class = $class_reflector->newInstanceArgs($params);
+		$object->$method($_class);
 
 		foreach ($extras as $k) {
 			if (!empty($$k)) {


### PR DESCRIPTION
The current switch obviously doesn't work with more than 5 arguments, which some Handlers need -- so we use reflection to craft the class instance instead.
